### PR TITLE
gender options and remove <p> for new story

### DIFF
--- a/AntraShare/src/app/feature/news-feed/news-feed/story/new-story/new-story.component.ts
+++ b/AntraShare/src/app/feature/news-feed/news-feed/story/new-story/new-story.component.ts
@@ -35,7 +35,7 @@ export class NewStoryComponent {
         publisherName: postUser?.name ?? 'guest',
         publishedTime: new Date().toISOString(),
         content: {
-          text: this.text,
+          text: this.text.substring(3, this.text.length - 4),
         },
         comment: [],
       })

--- a/AntraShare/src/app/feature/user/profile/profile.component.html
+++ b/AntraShare/src/app/feature/user/profile/profile.component.html
@@ -38,7 +38,7 @@
         <p-card>
             <div>
                 <span class="profile__label">Gender</span>
-                <p-dropdown [options]="genderOptions" optionLabel="Gender"></p-dropdown>
+                <p-dropdown [options]="genderOptions"></p-dropdown>
             </div>
         </p-card>
         <p-card>


### PR DESCRIPTION
Previously, the gender options on the profile page were: "empty", "empty", and "empty" due to incorrect component option optionLabel.

Previously, when posting a new story, the <p></p> tag was included as content. This bugfix removed the unnecessary p tag.

@TangMutian Please review!